### PR TITLE
fix: scroll for the 3D animation is now more stable

### DIFF
--- a/src/components/planets/Canvas.tsx
+++ b/src/components/planets/Canvas.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useState } from "react";
 import { Canvas } from "@react-three/fiber";
 import { NoToneMapping } from "three";
+import { useScrollPosition } from "@n8tb1t/use-scroll-position";
 
 import Composer from "./Composer";
 import PlanetsAndStars from "./PlanetsAndStars";
@@ -11,6 +12,14 @@ interface CanvasProps {
 }
 
 const CanvasComponent = ({ pixelSize = 100 }: CanvasProps) => {
+  const [scrollPositionY, setScrollPositionY] = useState(0);
+
+  console.log("scrollPositionY", scrollPositionY);
+
+  useScrollPosition(({ currPos }) => {
+    setScrollPositionY(currPos.y);
+  });
+
   return (
     <div className="fixed top-0 h-full w-full">
       <Canvas
@@ -22,9 +31,9 @@ const CanvasComponent = ({ pixelSize = 100 }: CanvasProps) => {
         }}
         linear
       >
-        <Composer pixelSize={pixelSize} />
+        <Composer scrollPositionY={scrollPositionY} />
         <Camera />
-        <PlanetsAndStars />
+        <PlanetsAndStars scrollPositionY={scrollPositionY} />
       </Canvas>
     </div>
   );

--- a/src/components/planets/Canvas.tsx
+++ b/src/components/planets/Canvas.tsx
@@ -7,14 +7,8 @@ import Composer from "./Composer";
 import PlanetsAndStars from "./PlanetsAndStars";
 import Camera from "./Camera";
 
-interface CanvasProps {
-  pixelSize?: number;
-}
-
-const CanvasComponent = ({ pixelSize = 100 }: CanvasProps) => {
+const CanvasComponent = () => {
   const [scrollPositionY, setScrollPositionY] = useState(0);
-
-  console.log("scrollPositionY", scrollPositionY);
 
   useScrollPosition(({ currPos }) => {
     setScrollPositionY(currPos.y);

--- a/src/components/planets/Composer.tsx
+++ b/src/components/planets/Composer.tsx
@@ -6,11 +6,13 @@ import { ShaderPass } from "three/examples/jsm/postprocessing/ShaderPass";
 import { PixelShader } from "three/examples/jsm/shaders/PixelShader.js";
 import * as THREE from "three";
 
+const maxPixelSize = 100;
+
 interface ComposerProps {
-  pixelSize: number;
+  scrollPositionY: number;
 }
 
-const Composer = ({ pixelSize }: ComposerProps) => {
+const Composer = ({ scrollPositionY }: ComposerProps) => {
   const { gl, scene, camera, size } = useThree();
 
   const shaders = useMemo(() => {
@@ -35,8 +37,20 @@ const Composer = ({ pixelSize }: ComposerProps) => {
   }, []);
 
   useEffect(() => {
-    shaders.pixel.uniforms["pixelSize"].value = pixelSize;
-  }, [pixelSize]);
+    if (window && document) {
+      const pixelSize =
+        window.scrollY > 50
+          ? Math.round(
+              Math.max(
+                (window.scrollY / document.documentElement.scrollHeight) *
+                  maxPixelSize,
+                1,
+              ),
+            )
+          : 1;
+      shaders.pixel.uniforms["pixelSize"].value = pixelSize;
+    }
+  }, [scrollPositionY]);
 
   useEffect(() => {
     shaders.pixel.uniforms["resolution"].value = new THREE.Vector2(

--- a/src/components/planets/PlanetsAndStars.tsx
+++ b/src/components/planets/PlanetsAndStars.tsx
@@ -4,30 +4,22 @@ import * as THREE from "three";
 
 import Stars from "./Stars";
 import { Paris, Miyajima, Sintra } from ".";
-import { useScrollPosition } from "@n8tb1t/use-scroll-position";
-import { delta, updateDelta } from "./constants";
+import { updateDelta } from "./constants";
 
 const transitionSpeed = 0.1;
 
-const PlanetsAndStars = () => {
-  const [scrollPositionY, setScrollPositionY] = useState(0);
-
-  useScrollPosition(({ currPos }) => {
-    setScrollPositionY(currPos.y * -0.01);
-  });
-
+const PlanetsAndStars = ({ scrollPositionY }: { scrollPositionY: number }) => {
   const [groupRef, setGroupRef] = useState<THREE.Group | null>(null);
 
   useFrame(() => {
-    const speed = transitionSpeed * delta;
     if (groupRef) {
       // This is adjusted based on the frame rate of the website
       // It will stabilize the animation speed
       updateDelta();
       groupRef.position.y = THREE.MathUtils.lerp(
         groupRef.position.y,
-        scrollPositionY,
-        speed,
+        scrollPositionY * -0.01,
+        transitionSpeed,
       );
     }
   });

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -164,10 +164,8 @@ export const getStaticProps = async () => {
 
 const colorPrimary = "bg-blue-950";
 const colorSecondary = "bg-blue-800";
-const maxPixelSize = 200;
 
 const HomePage = ({ data }: InferGetStaticPropsType<typeof getStaticProps>) => {
-  const [pixelSize, setPixelSize] = useState(1);
   const pageId = InternalLinksIds.home;
   const pageData = internalLinks[pageId];
 
@@ -178,23 +176,8 @@ const HomePage = ({ data }: InferGetStaticPropsType<typeof getStaticProps>) => {
         colorSecondary={colorSecondary}
         pageId={pageId}
       />
-      <Canvas pixelSize={pixelSize} />
-      <main
-        className="z-1 pointer-events-none relative"
-        onWheel={() => {
-          if (window && document) {
-            setPixelSize(
-              Math.round(
-                Math.max(
-                  (window.scrollY / document.documentElement.scrollHeight) *
-                    maxPixelSize,
-                  1,
-                ),
-              ),
-            );
-          }
-        }}
-      >
+      <Canvas />
+      <main className="z-1 pointer-events-none relative">
         <HomeHero />
         <HomeWorkExperienceSection
           workExperiences={data.sectionWorkExperiences.workExperiences}


### PR DESCRIPTION
# Changes

- The pixellated effect was not happening consistently, since the trigger for it was placed on a container div, with an event happening on the wheel. However, this parent div has "pointer events none" on it, which means the event was getting triggered only when the user's cursor was above one of its children element with "pointer events all" on it. This is now fixed by using the same scroll event listener which is used to determine the positions of the planets and stars.
- The transition speed for the position of the planets and stars was also updated: before it used delta to stabilize the animation speed, base on the performance of the user desktop, which made it too slow (it needed more than a minute for the transition to happen), it now uses a hard coded value.

# Tested in

- Brave