### PR TITLE
add: filter for the all articles and all projects pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react": "18.2",
     "react-dom": "^18",
     "react-redux": "^9.1.0",
+    "react-select": "^5.8.0",
     "redux": "^5.0.1",
     "sanity": "3.25",
     "styled-components": "6.0",

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -2,12 +2,10 @@ import Head from "next/head";
 import { Lexend } from "next/font/google";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
-import { Provider } from "react-redux";
 import { metadata as metaDataConstants, MenuComponentProps } from "@/models";
 import "@/styles/globals.css";
 import { Menu } from "@/components";
 import Footer from "./Footer";
-import store from "@/store";
 
 const lexend = Lexend({ subsets: ["latin"] });
 
@@ -27,51 +25,51 @@ const Layout = ({
   colorSecondary,
   pageId,
   bottomNavigationLinks,
+  skillsFilter,
 }: LayoutProps) => {
   return (
-    <Provider store={store}>
-      <div className={lexend.className}>
-        <Head>
-          <meta charSet="utf-8" />
-          <title>{`Ludi | ${title}`}</title>
-          {/* appears in search results */}
-          <meta
-            name="description"
-            content={metaDataConstants.description as string}
-          />
-          <link rel="icon" href="/favicon.png" />
-          {/* open graph */}
-          <meta property="og:type" content="website" />
-          <meta property="og:title" content={`Ludivine Constanti | ${title}`} />
-          <meta
-            property="og:description"
-            content={metaDataConstants.description as string}
-          />
-          <meta property="og:image" content="/opengraph-image.jpg" />
-          {/* twitter */}
-          <meta name="twitter:card" content="summary_large_image" />
-          <meta
-            property="twitter:title"
-            content={`Ludivine Constanti | ${title}`}
-          />
-          <meta
-            property="twitter:description"
-            content={metaDataConstants.description as string}
-          />
-          <meta property="twitter:image" content="/opengraph-image.jpg" />
-        </Head>
-        <Menu
-          colorPrimary={colorPrimary}
-          colorSecondary={colorSecondary}
-          pageId={pageId}
-          bottomNavigationLinks={bottomNavigationLinks}
+    <div className={lexend.className}>
+      <Head>
+        <meta charSet="utf-8" />
+        <title>{`Ludi | ${title}`}</title>
+        {/* appears in search results */}
+        <meta
+          name="description"
+          content={metaDataConstants.description as string}
         />
-        {children}
-        <Footer colorSecondary={colorSecondary} />
-        <Analytics />
-        <SpeedInsights />
-      </div>
-    </Provider>
+        <link rel="icon" href="/favicon.png" />
+        {/* open graph */}
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content={`Ludivine Constanti | ${title}`} />
+        <meta
+          property="og:description"
+          content={metaDataConstants.description as string}
+        />
+        <meta property="og:image" content="/opengraph-image.jpg" />
+        {/* twitter */}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta
+          property="twitter:title"
+          content={`Ludivine Constanti | ${title}`}
+        />
+        <meta
+          property="twitter:description"
+          content={metaDataConstants.description as string}
+        />
+        <meta property="twitter:image" content="/opengraph-image.jpg" />
+      </Head>
+      <Menu
+        colorPrimary={colorPrimary}
+        colorSecondary={colorSecondary}
+        pageId={pageId}
+        bottomNavigationLinks={bottomNavigationLinks}
+        skillsFilter={skillsFilter}
+      />
+      {children}
+      <Footer colorSecondary={colorSecondary} />
+      <Analytics />
+      <SpeedInsights />
+    </div>
   );
 };
 

--- a/src/components/NoArticlesOrProjectsFound.tsx
+++ b/src/components/NoArticlesOrProjectsFound.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import LinkCTA from "./LinkCTA";
+import { internalLinks } from "../models/constantsMenu";
+import { useAppSelector } from "@/store";
+
+const NoArticlesOrProjectsFound = ({
+  linksToArticlesOrProjects,
+}: {
+  linksToArticlesOrProjects: "articles" | "projects";
+}) => {
+  const {
+    selectedSkillsFilter,
+    howManyArticlesAreVisible,
+    howManyProjectsAreVisible,
+  } = useAppSelector((state) => state.system);
+  const number =
+    linksToArticlesOrProjects === "projects"
+      ? howManyProjectsAreVisible
+      : howManyArticlesAreVisible;
+  const text =
+    linksToArticlesOrProjects === "projects"
+      ? `Project${howManyProjectsAreVisible > 1 ? "s" : ""}`
+      : `Article${howManyArticlesAreVisible > 1 ? "s" : ""}`;
+  return (
+    <div className="mx-custom all-projects-all-articles-pt flex h-full grow items-center justify-center">
+      <div className="flex max-w-[50rem] flex-col gap-16">
+        <p className="text-h3">
+          There are currently no{" "}
+          {linksToArticlesOrProjects === "projects" ? "Articles" : "Projects"}{" "}
+          matching{" "}
+          {selectedSkillsFilter.length > 1 ? "these skills" : "this skill"}, but
+          you can find {number} {text}{" "}
+          {linksToArticlesOrProjects === "projects" ? "using it" : "about it"}{" "}
+          on the {text} page
+        </p>
+        <LinkCTA
+          href={
+            linksToArticlesOrProjects === "projects"
+              ? internalLinks.allProjects.href
+              : internalLinks.allArticles.href
+          }
+          text={`${number} ${text}`}
+          color="bg-blue-800"
+          alignCenter={false}
+          marginBottom="none"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default NoArticlesOrProjectsFound;

--- a/src/components/NoArticlesOrProjectsFound.tsx
+++ b/src/components/NoArticlesOrProjectsFound.tsx
@@ -5,8 +5,10 @@ import { useAppSelector } from "@/store";
 
 const NoArticlesOrProjectsFound = ({
   linksToArticlesOrProjects,
+  color,
 }: {
   linksToArticlesOrProjects: "articles" | "projects";
+  color: string;
 }) => {
   const {
     selectedSkillsFilter,
@@ -40,7 +42,7 @@ const NoArticlesOrProjectsFound = ({
               : internalLinks.allArticles.href
           }
           text={`${number} ${text}`}
-          color="bg-blue-800"
+          color={color}
           alignCenter={false}
           marginBottom="none"
         />

--- a/src/components/ProjectLink.tsx
+++ b/src/components/ProjectLink.tsx
@@ -1,9 +1,10 @@
+import React from "react";
 import clsx from "clsx";
 import Image from "next/image";
 import Link from "next/link";
 import type { ProjectData } from "@/models";
 import { SkillBadgeList, ArrowForward } from "@/components";
-import { returnProjectOrArticleYear } from "@/utils";
+import { returnProjectOrArticleYear, returnVisibleSkillBadges } from "@/utils";
 
 const Project = ({
   workExperience,
@@ -21,6 +22,8 @@ const Project = ({
   const start = new Date(dateStart).getFullYear();
   const end = returnProjectOrArticleYear(dateEnd, true);
 
+  const visibleSkillBadges = returnVisibleSkillBadges(skillBadges);
+
   return (
     <li>
       <Link
@@ -31,7 +34,7 @@ const Project = ({
         )}
       >
         {image && (
-          <div className="flex w-full flex-shrink-0 overflow-hidden rounded-lg xl:w-[33%]">
+          <div className="flex h-fit w-full flex-shrink-0 overflow-hidden rounded-lg xl:w-[33%]">
             <Image
               className="h-full w-full object-cover"
               src={image.url}
@@ -56,7 +59,7 @@ const Project = ({
           <SkillBadgeList
             size="small"
             color={colorSkillBadge}
-            skillBadges={skillBadges}
+            skillBadges={visibleSkillBadges}
           />
         </div>
         <div
@@ -72,4 +75,4 @@ const Project = ({
   );
 };
 
-export default Project;
+export default React.memo(Project);

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,6 +9,7 @@ export { default as ProjectLink } from "./ProjectLink";
 export { default as ProjectLinkList } from "./ProjectLinkList";
 export { default as ArticleList } from "./ArticleList";
 export { default as Tooltip } from "./Tooltip";
+export { default as NoArticlesOrProjectsFound } from "./NoArticlesOrProjectsFound";
 export * from "./planets";
 
 /* PAGES */

--- a/src/components/menu/InternalLink.tsx
+++ b/src/components/menu/InternalLink.tsx
@@ -2,6 +2,8 @@ import Link from "next/link";
 import clsx from "clsx";
 import React from "react";
 import { ArrowForward } from "../icons";
+import { useAppSelector } from "@/store";
+import { internalLinks } from "@/models";
 
 const InternalLink = ({
   text,
@@ -12,10 +14,26 @@ const InternalLink = ({
   href: string;
   color: string;
 }) => {
+  const {
+    selectedSkillsFilter,
+    howManyArticlesAreVisible,
+    howManyProjectsAreVisible,
+  } = useAppSelector((state) => state.system);
+
+  let textContent = text;
+
+  if (selectedSkillsFilter.length > 0) {
+    if (href === internalLinks.allProjects.href) {
+      textContent = `${howManyProjectsAreVisible} Project${howManyProjectsAreVisible > 1 ? "s" : ""}`;
+    } else if (href === internalLinks.allArticles.href) {
+      textContent = `${howManyArticlesAreVisible} Article${howManyArticlesAreVisible > 1 ? "s" : ""}`;
+    }
+  }
+
   return (
     <li>
       <Link className={clsx(color, "menu-link gap-2")} href={href}>
-        {text}
+        {textContent}
         <span className="w-3.5">
           <ArrowForward />
         </span>

--- a/src/components/menu/SearchBar.tsx
+++ b/src/components/menu/SearchBar.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import React from "react";
+import { SearchBarComponentProps } from "@/models";
+import { useAppDispatch } from "@/store";
+import { setSelectedSkillsFilter } from "@/store/slices/system";
+import { useAppSelector } from "@/store";
+
+const Select = dynamic(() => import("react-select"));
+
+const SearchBar = ({
+  skillsFilter,
+}: {
+  skillsFilter: SearchBarComponentProps;
+}) => {
+  const dispatch = useAppDispatch();
+  const { selectedSkillsFilter } = useAppSelector((state) => state.system);
+  return (
+    <Select
+      id="react-select-menu-search-bar"
+      placeholder="Filter by skills"
+      options={skillsFilter}
+      isSearchable={true}
+      isMulti={true}
+      unstyled={true}
+      value={selectedSkillsFilter}
+      onChange={(v) => {
+        dispatch(setSelectedSkillsFilter(v));
+      }}
+      classNames={{
+        container: () =>
+          "outline-2 outline-white text-body min-h-fit text-blue-950 border-solid min-w-44 max-w-[calc(100vw-10rem)] xl:max-w-[40rem] border-2 border-blue-950 min-w-30 px-2 bg-white rounded-2xl pointer-events-auto",
+        dropdownIndicator: () => "[&>svg>path]:fill-blue-800 cursor-pointer",
+        control: () => "min-h-fit",
+        placeholder: () => "text-gray-500",
+        // dropdown
+        menuList: () => "-bottom-2 -left-2 rounded-lg py-2 bg-white",
+        option: () => "cursor-pointer hover:bg-blue-100 bg-white px-2 py-0.5",
+        // selected values
+        valueContainer: () => "gap-1.5 flex py-1",
+        multiValue: () => "bg-blue-200 rounded-sm px-1 flex gap-0.5",
+      }}
+    />
+  );
+};
+
+export default SearchBar;

--- a/src/components/menu/SearchBar.tsx
+++ b/src/components/menu/SearchBar.tsx
@@ -30,7 +30,7 @@ const SearchBar = ({
       }}
       classNames={{
         container: () =>
-          "outline-2 outline-white text-body min-h-fit text-blue-950 border-solid min-w-44 max-w-[calc(100vw-10rem)] xl:max-w-[40rem] border-2 border-blue-950 min-w-30 px-2 bg-white rounded-2xl pointer-events-auto",
+          "outline-2 outline-white text-body min-h-fit text-blue-950 border-solid min-w-44 sm:max-w-52 max-w-[calc(100vw-10rem)] xl:max-w-[40rem] border-2 border-blue-950 min-w-30 px-2 bg-white rounded-2xl pointer-events-auto",
         dropdownIndicator: () => "[&>svg>path]:fill-blue-800 cursor-pointer",
         control: () => "min-h-fit",
         placeholder: () => "text-gray-500",

--- a/src/components/menu/index.tsx
+++ b/src/components/menu/index.tsx
@@ -28,6 +28,8 @@ const menuLinksKeys = internalLinksKeys.filter(
   (e) => internalLinks[e].showInMenu,
 );
 
+const classNameMenuGap = "gap-8 sm:gap-4 xl:gap-8";
+
 const Menu = ({
   colorPrimary,
   colorSecondary,
@@ -76,16 +78,27 @@ const Menu = ({
         setMenuIsOpen={setMenuIsOpen}
         color={colorPrimary}
       />
-      <div className="flex w-full justify-center gap-8 sm:absolute sm:top-6 sm:items-start xl:top-7">
+      <div
+        className={clsx(
+          classNameMenuGap,
+          "z-10 flex w-full justify-center sm:absolute sm:top-6 sm:mx-4 sm:items-start xl:top-7",
+        )}
+      >
         <div
           className={clsx(
             { hidden: !menuIsOpen },
             colorPrimary,
-            "flex w-full flex-col items-center justify-center gap-8 p-16 sm:flex sm:w-fit sm:flex-row sm:bg-[rgba(255,255,255,0)] sm:p-0",
+            classNameMenuGap,
+            "flex w-full flex-col items-center justify-center p-16 sm:flex sm:w-fit sm:flex-row sm:bg-[rgba(255,255,255,0)] sm:p-0",
           )}
         >
           <nav>
-            <ul className="flex flex-col items-center justify-center gap-8 sm:flex-row">
+            <ul
+              className={clsx(
+                classNameMenuGap,
+                "flex flex-col items-center justify-center sm:flex-row",
+              )}
+            >
               {menuLinksKeys
                 .filter((internalLinkKey) => internalLinkKey !== pageId)
                 .map((internalLinkKey) => (

--- a/src/components/menu/index.tsx
+++ b/src/components/menu/index.tsx
@@ -2,9 +2,11 @@
 
 import React, { useState, useEffect } from "react";
 import clsx from "clsx";
+
 import InternalLink from "./InternalLink";
 import SocialMedia from "./SocialMedia";
 import ButtonClose from "./ButtonClose";
+import SearchBar from "./SearchBar";
 import { ArrowDownload } from "..";
 import {
   internalLinks,
@@ -31,6 +33,7 @@ const Menu = ({
   colorSecondary,
   pageId,
   bottomNavigationLinks,
+  skillsFilter,
 }: MenuComponentProps) => {
   const dispatch = useAppDispatch();
   const [menuIsOpen, setMenuIsOpen] = useState(false);
@@ -73,23 +76,27 @@ const Menu = ({
         setMenuIsOpen={setMenuIsOpen}
         color={colorPrimary}
       />
-      <nav
-        className={clsx(
-          { "hidden sm:flex": !menuIsOpen },
-          colorPrimary,
-          "flex w-full justify-center sm:absolute sm:top-6 sm:block sm:bg-[rgba(255,255,255,0)] xl:top-7",
-        )}
-      >
-        <ul className="flex flex-col items-center justify-center gap-8 p-16 sm:flex-row sm:p-0">
-          {menuLinksKeys
-            .filter((internalLinkKey) => internalLinkKey !== pageId)
-            .map((internalLinkKey) => (
-              <InternalLink
-                color={colorPrimary}
-                key={`internal-link-${internalLinkKey}`}
-                {...internalLinks[internalLinkKey]}
-              />
-            ))}
+      <div className="flex w-full justify-center gap-8 sm:absolute sm:top-6 sm:items-start xl:top-7">
+        <div
+          className={clsx(
+            { hidden: !menuIsOpen },
+            colorPrimary,
+            "flex w-full flex-col items-center justify-center gap-8 p-16 sm:flex sm:w-fit sm:flex-row sm:bg-[rgba(255,255,255,0)] sm:p-0",
+          )}
+        >
+          <nav>
+            <ul className="flex flex-col items-center justify-center gap-8 sm:flex-row">
+              {menuLinksKeys
+                .filter((internalLinkKey) => internalLinkKey !== pageId)
+                .map((internalLinkKey) => (
+                  <InternalLink
+                    color={colorPrimary}
+                    key={`internal-link-${internalLinkKey}`}
+                    {...internalLinks[internalLinkKey]}
+                  />
+                ))}
+            </ul>
+          </nav>
           <a
             href="/resume_Ludivine_Constanti.pdf"
             className={clsx(colorPrimary, "menu-link gap-1.5")}
@@ -100,8 +107,13 @@ const Menu = ({
               <ArrowDownload />
             </span>
           </a>
-        </ul>
-      </nav>
+        </div>
+        {skillsFilter && menuIsOpen === false && (
+          <div className="relative top-5 sm:top-0">
+            <SearchBar skillsFilter={skillsFilter} />
+          </div>
+        )}
+      </div>
       <ul
         className={clsx(
           { "hidden sm:flex": !menuIsOpen },

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -15,6 +15,8 @@ export interface SkillBadgeData {
   _id: string;
   emoji: string;
   text: string;
+  techStack: true | null;
+  highlighted: true | null;
 }
 
 interface ArticleCategoryData {

--- a/src/models/modelsComponents.ts
+++ b/src/models/modelsComponents.ts
@@ -6,9 +6,12 @@ export type BottomNavigationComponentProps = {
   text: string;
 }[];
 
+export type SearchBarComponentProps = { value: string; label: string }[];
+
 export interface MenuComponentProps {
   colorPrimary: string;
   colorSecondary: string;
   pageId?: InternalLinksIds;
   bottomNavigationLinks?: BottomNavigationComponentProps;
+  skillsFilter?: SearchBarComponentProps;
 }

--- a/src/pages/[project].tsx
+++ b/src/pages/[project].tsx
@@ -13,7 +13,11 @@ import {
 import { SlugProps, SkillBadgeData } from "@/models";
 import { groq } from "next-sanity";
 import { client, querySkillBadges } from "@/sanity/utils";
-import { sortAlphabetically, returnProjectOrArticleYear } from "@/utils";
+import {
+  sortAlphabetically,
+  returnProjectOrArticleYear,
+  returnVisibleSkillBadges,
+} from "@/utils";
 
 // Returns a list of possible value for the projects id
 export const getStaticPaths = async () => {
@@ -222,7 +226,7 @@ export const getStaticProps = async ({
         ...data[0],
         dateStart: new Date(data[0].dateStart).getFullYear(),
         dateEnd: returnProjectOrArticleYear(data[0].dateEnd, true),
-        skillBadges,
+        skillBadges: returnVisibleSkillBadges(skillBadges, 15),
         role: role[0],
         client: projectClient,
         projectLinks: projectLinks.length ? projectLinks : null,

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,0 +1,13 @@
+import type { AppProps } from "next/app";
+import store from "@/store";
+import { Provider } from "react-redux";
+
+const MyApp = ({ Component, pageProps }: AppProps) => {
+  return (
+    <Provider store={store}>
+      <Component {...pageProps} />
+    </Provider>
+  );
+};
+
+export default MyApp;

--- a/src/pages/all-articles.tsx
+++ b/src/pages/all-articles.tsx
@@ -1,20 +1,84 @@
+import { useEffect, startTransition } from "react";
 import type { InferGetStaticPropsType } from "next";
 import { groq } from "next-sanity";
 import clsx from "clsx";
 import { client, queryArticleLink } from "@/sanity/utils";
-import { sortAlphabetically, returnProjectOrArticleYear } from "@/utils";
+import {
+  sortAlphabetically,
+  returnProjectOrArticleYear,
+  returnDataBasedOnFilterState,
+  returnSkillsForFilter,
+} from "@/utils";
 import type { ArticleData } from "@/models";
 import { internalLinks, InternalLinksIds } from "@/models";
-import { TitlePage, AllArticlesArticleListPerYear, Layout } from "@/components";
+import {
+  TitlePage,
+  AllArticlesArticleListPerYear,
+  Layout,
+  NoArticlesOrProjectsFound,
+} from "@/components";
+import { useAppSelector, useAppDispatch } from "@/store";
+import { setHowManyArticlesAndProjectsAreVisible } from "@/store/slices/system";
 
 export const getStaticProps = async () => {
-  const data = await client.fetch(groq`*[_type == "article"] | order(date desc){
+  const projects =
+    await client.fetch(groq`*[_type == "project"] | order(dateEnd desc){
+    skillBadges[]->{_id}  
+    }`);
+  const articles =
+    await client.fetch(groq`*[_type == "article"] | order(date desc){
     ${queryArticleLink}
   }`);
 
-  const sortedData: { [key: string]: { [key: string]: ArticleData[] } } = {};
+  const dataSkills =
+    (await client.fetch(groq`*[_type == "skillBadge"] | order(text asc){
+  _id,
+  text,
+}`)) as { _id: string; text: string }[];
 
-  data.forEach((article: ArticleData) => {
+  const skillsFilter = returnSkillsForFilter({
+    data: dataSkills,
+    projects,
+    articles,
+  });
+
+  return {
+    props: {
+      data: {
+        projects,
+        skillsFilter,
+        articles,
+      },
+    },
+  };
+};
+
+const colorPrimary = "bg-violet-950";
+const colorSecondary = "bg-violet-800";
+
+const AllArticlesPage = ({
+  data,
+}: InferGetStaticPropsType<typeof getStaticProps>) => {
+  const dispatch = useAppDispatch();
+
+  const pageId = InternalLinksIds.allArticles;
+  const pageData = internalLinks[InternalLinksIds.allArticles];
+
+  const { selectedSkillsFilter } = useAppSelector((state) => state.system);
+
+  const projectsLength = returnDataBasedOnFilterState(
+    data.projects,
+    selectedSkillsFilter,
+  ).length;
+
+  const initialArticlesData =
+    selectedSkillsFilter.length === 0
+      ? data.articles
+      : returnDataBasedOnFilterState(data.articles, selectedSkillsFilter);
+
+  const articles: { [key: string]: { [key: string]: ArticleData[] } } = {};
+
+  initialArticlesData.forEach((article: ArticleData) => {
     const year = returnProjectOrArticleYear(article.date);
     const skillBadges = article.skillBadges
       ? sortAlphabetically(article.skillBadges)
@@ -29,58 +93,62 @@ export const getStaticProps = async () => {
       key = currentArticle.category.text;
     }
 
-    if (sortedData[year]) {
-      if (sortedData[year][key]) {
-        sortedData[year][key].push(currentArticle);
+    if (articles[year]) {
+      if (articles[year][key]) {
+        articles[year][key].push(currentArticle);
       } else {
-        sortedData[year][key] = [currentArticle];
+        articles[year][key] = [currentArticle];
       }
     } else {
-      sortedData[year] = {};
-      sortedData[year][key] = [currentArticle];
+      articles[year] = {};
+      articles[year][key] = [currentArticle];
     }
   });
 
-  return {
-    props: {
-      data: {
-        articles: sortedData,
-      },
-    },
-  };
-};
+  useEffect(() => {
+    startTransition(() => {
+      dispatch(
+        setHowManyArticlesAndProjectsAreVisible({
+          projects: projectsLength,
+          articles: initialArticlesData.length,
+        }),
+      );
+    });
+  }, [dispatch, initialArticlesData, projectsLength]);
 
-const colorPrimary = "bg-violet-950";
-const colorSecondary = "bg-violet-800";
-
-const AllArticlesPage = ({
-  data,
-}: InferGetStaticPropsType<typeof getStaticProps>) => {
-  const pageId = InternalLinksIds.allArticles;
-  const pageData = internalLinks[InternalLinksIds.allArticles];
   return (
     <Layout
       title={pageData.text}
       colorPrimary={colorPrimary}
       colorSecondary={colorSecondary}
       pageId={pageId}
-      bottomNavigationLinks={Object.keys(data.articles)
+      bottomNavigationLinks={Object.keys(articles)
         .reverse()
         .map((year) => ({
           href: year,
           text: year,
         }))}
+      skillsFilter={data.skillsFilter}
     >
-      <main className={clsx(colorPrimary, "all-projects-all-articles-pb")}>
+      <main
+        className={clsx(
+          colorPrimary,
+          "all-projects-all-articles-pb min-h-[100vh]",
+        )}
+      >
         <TitlePage
           emoji={pageData.emoji}
           text={pageData.text}
           color={colorSecondary}
         />
-        <AllArticlesArticleListPerYear
-          articles={data.articles}
-          color={colorSecondary}
-        />
+        {Object.keys(articles).length > 0 ? (
+          <AllArticlesArticleListPerYear
+            articles={articles}
+            color={colorSecondary}
+          />
+        ) : (
+          <NoArticlesOrProjectsFound linksToArticlesOrProjects="projects" />
+        )}
       </main>
     </Layout>
   );

--- a/src/pages/all-articles.tsx
+++ b/src/pages/all-articles.tsx
@@ -147,7 +147,10 @@ const AllArticlesPage = ({
             color={colorSecondary}
           />
         ) : (
-          <NoArticlesOrProjectsFound linksToArticlesOrProjects="projects" />
+          <NoArticlesOrProjectsFound
+            linksToArticlesOrProjects="projects"
+            color={colorSecondary}
+          />
         )}
       </main>
     </Layout>

--- a/src/pages/all-projects.tsx
+++ b/src/pages/all-projects.tsx
@@ -1,43 +1,53 @@
+import { useEffect, startTransition } from "react";
 import type { InferGetStaticPropsType } from "next";
 import { groq } from "next-sanity";
 import clsx from "clsx";
 import { client, queryProjectLink } from "@/sanity/utils";
-import type { ProjectData } from "@/models";
+import type { ProjectData, ArticleData } from "@/models";
 import {
   Layout,
   TitlePage,
   AllProjectsProjectListsWithTitle,
+  NoArticlesOrProjectsFound,
 } from "@/components";
 import { internalLinks, InternalLinksIds } from "@/models";
-import { returnProjectOrArticleYear } from "@/utils";
+import {
+  returnProjectOrArticleYear,
+  returnDataBasedOnFilterState,
+  returnSkillsForFilter,
+} from "@/utils";
+import { useAppSelector, useAppDispatch } from "@/store";
+import { setHowManyArticlesAndProjectsAreVisible } from "@/store/slices/system";
 
 export const getStaticProps = async () => {
-  const data =
+  const projects: ProjectData[] =
     await client.fetch(groq`*[_type == "project"] | order(dateEnd desc){
     ${queryProjectLink}  
     }`);
 
-  const sortedData: { [key: string]: ProjectData[] } = {};
+  const articles: ArticleData[] =
+    await client.fetch(groq`*[_type == "article"] {
+  skillBadges[]->{_id} 
+  }`);
 
-  data.forEach((project: ProjectData) => {
-    const year = returnProjectOrArticleYear(project.dateEnd);
+  const dataSkills =
+    (await client.fetch(groq`*[_type == "skillBadge"] | order(text asc){
+    _id,
+    text,
+  }`)) as { _id: string; text: string }[];
 
-    const skillBadges = project.skillBadges
-      ? project.skillBadges.sort((a, b) => (a.text > b.text ? 1 : -1))
-      : [];
-    const currentProject = { ...project, skillBadges };
-
-    if (sortedData[year]) {
-      sortedData[year].push(currentProject);
-    } else {
-      sortedData[year] = [currentProject];
-    }
+  const skillsFilter = returnSkillsForFilter({
+    data: dataSkills,
+    projects,
+    articles,
   });
 
   return {
     props: {
       data: {
-        projects: sortedData,
+        projects,
+        articles,
+        skillsFilter,
       },
     },
   };
@@ -49,8 +59,49 @@ const colorSecondary = "bg-blue-800";
 const AllProjectsPage = ({
   data,
 }: InferGetStaticPropsType<typeof getStaticProps>) => {
+  const dispatch = useAppDispatch();
   const pageId = InternalLinksIds.allProjects;
   const pageData = internalLinks[pageId];
+
+  const { selectedSkillsFilter } = useAppSelector((state) => state.system);
+
+  const projects: { [key: string]: ProjectData[] } = {};
+
+  const articlesLength = returnDataBasedOnFilterState(
+    data.articles,
+    selectedSkillsFilter,
+  ).length;
+
+  const initialProjectsData =
+    selectedSkillsFilter.length === 0
+      ? data.projects
+      : returnDataBasedOnFilterState(data.projects, selectedSkillsFilter);
+
+  initialProjectsData.forEach((project) => {
+    const year = returnProjectOrArticleYear(project.dateEnd);
+
+    const skillBadges = project.skillBadges
+      ? project.skillBadges.sort((a, b) => (a.text > b.text ? 1 : -1))
+      : [];
+    const currentProject = { ...project, skillBadges };
+
+    if (projects[year]) {
+      projects[year].push(currentProject);
+    } else {
+      projects[year] = [currentProject];
+    }
+  });
+
+  useEffect(() => {
+    startTransition(() => {
+      dispatch(
+        setHowManyArticlesAndProjectsAreVisible({
+          projects: initialProjectsData.length,
+          articles: articlesLength,
+        }),
+      );
+    });
+  }, [dispatch, initialProjectsData, articlesLength]);
 
   return (
     <Layout
@@ -58,23 +109,33 @@ const AllProjectsPage = ({
       colorPrimary={colorPrimary}
       colorSecondary={colorSecondary}
       pageId={pageId}
-      bottomNavigationLinks={Object.keys(data.projects)
+      bottomNavigationLinks={Object.keys(projects)
         .reverse()
         .map((year) => ({
           href: year,
           text: year,
         }))}
+      skillsFilter={data.skillsFilter}
     >
-      <main className={clsx(colorPrimary, "all-projects-all-articles-pb")}>
+      <main
+        className={clsx(
+          colorPrimary,
+          "all-projects-all-articles-pb flex min-h-[100vh] flex-col",
+        )}
+      >
         <TitlePage
           emoji={pageData.emoji}
           text={pageData.text}
           color={colorSecondary}
         />
-        <AllProjectsProjectListsWithTitle
-          color={colorSecondary}
-          projects={data.projects}
-        />
+        {Object.keys(projects).length > 0 ? (
+          <AllProjectsProjectListsWithTitle
+            color={colorSecondary}
+            projects={projects}
+          />
+        ) : (
+          <NoArticlesOrProjectsFound linksToArticlesOrProjects="articles" />
+        )}
       </main>
     </Layout>
   );

--- a/src/pages/all-projects.tsx
+++ b/src/pages/all-projects.tsx
@@ -134,7 +134,10 @@ const AllProjectsPage = ({
             projects={projects}
           />
         ) : (
-          <NoArticlesOrProjectsFound linksToArticlesOrProjects="articles" />
+          <NoArticlesOrProjectsFound
+            linksToArticlesOrProjects="articles"
+            color={colorSecondary}
+          />
         )}
       </main>
     </Layout>

--- a/src/sanity/schemas/skillBadge.ts
+++ b/src/sanity/schemas/skillBadge.ts
@@ -15,6 +15,16 @@ export default defineType({
       title: "Text",
       type: "string",
     }),
+    defineField({
+      name: "techStack",
+      title: "Tech stack",
+      type: "boolean",
+    }),
+    defineField({
+      name: "highlighted",
+      title: "highlighted",
+      type: "boolean",
+    }),
   ],
   preview: {
     select: {

--- a/src/store/slices/system.ts
+++ b/src/store/slices/system.ts
@@ -1,19 +1,41 @@
 import { createSlice } from "@reduxjs/toolkit";
 
+interface InitialStateProps {
+  width: number;
+  height: number;
+  selectedSkillsFilter: { value: string; label: string }[];
+  howManyArticlesAreVisible: number;
+  howManyProjectsAreVisible: number;
+}
+
 const systemSlice = createSlice({
   name: "system",
   initialState: {
     width: 0,
     height: 0,
-  },
+    selectedSkillsFilter: [],
+    howManyArticlesAreVisible: 0,
+    howManyProjectsAreVisible: 0,
+  } as InitialStateProps,
   reducers: {
     setWidthAndHeight: (state, action) => {
       state.width = action.payload.width;
       state.height = action.payload.height;
     },
+    setSelectedSkillsFilter: (state, action) => {
+      state.selectedSkillsFilter = action.payload;
+    },
+    setHowManyArticlesAndProjectsAreVisible: (state, action) => {
+      state.howManyArticlesAreVisible = action.payload.articles;
+      state.howManyProjectsAreVisible = action.payload.projects;
+    },
   },
 });
 
-export const { setWidthAndHeight } = systemSlice.actions;
+export const {
+  setWidthAndHeight,
+  setSelectedSkillsFilter,
+  setHowManyArticlesAndProjectsAreVisible,
+} = systemSlice.actions;
 
 export default systemSlice.reducer;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,5 @@
+import { SkillBadgeData } from "@/models";
+
 export const returnProjectOrArticleYear = (
   year?: Date | string,
   shouldReturnPresent = false,
@@ -56,4 +58,67 @@ export const sortByDateEnd = <T extends { dateEnd: Date }[]>(data: T): T => {
     }
     return 0;
   });
+};
+
+export const returnDataBasedOnFilterState = <
+  T extends { skillBadges: { _id: string }[] }[],
+>(
+  data: T,
+  selectedSkillsFilter: { value: string }[],
+): T => {
+  const selectedSkillsFilterIds = selectedSkillsFilter.map((e) => e.value);
+  const newData = data.filter((item) => {
+    return item.skillBadges.some((skillBadge) => {
+      return selectedSkillsFilterIds.includes(skillBadge._id);
+    });
+  }) as T;
+  return newData;
+};
+
+export const returnSkillsForFilter = ({
+  data,
+  projects,
+  articles,
+}: {
+  data: { _id: string; text: string }[];
+  projects: { skillBadges: { _id: string }[] }[];
+  articles: { skillBadges: { _id: string }[] }[];
+}) => {
+  return data
+    .filter((skill) => {
+      const projectsHaveSkill = projects.some((project) => {
+        return project.skillBadges.some((projectSkill) => {
+          return projectSkill._id === skill._id;
+        });
+      });
+      const articlesHaveSkill = articles.some((article) => {
+        return article.skillBadges.some((articleSkill) => {
+          return articleSkill._id === skill._id;
+        });
+      });
+      return projectsHaveSkill || articlesHaveSkill;
+    })
+    .map((skill) => ({
+      value: skill._id,
+      label: skill.text,
+    }));
+};
+
+export const returnVisibleSkillBadges = (
+  skillBadges: SkillBadgeData[],
+  maxNumber?: number,
+) => {
+  const max = maxNumber || 10;
+  const filteredSkillBadges = skillBadges.filter(
+    (skillBadge) => skillBadge.techStack || skillBadge.highlighted,
+  );
+
+  let visibleSkillBadges = skillBadges;
+  if (visibleSkillBadges.length > max) {
+    visibleSkillBadges =
+      filteredSkillBadges.length <= max
+        ? filteredSkillBadges
+        : skillBadges.filter((skillBadge) => skillBadge.techStack);
+  }
+  return visibleSkillBadges;
 };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -14,11 +14,6 @@ const config: Config = {
   ],
   theme: {
     extend: {
-      backgroundImage: {
-        "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
-        "gradient-conic":
-          "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
-      },
       spacing: {
         "18": "4.5rem",
         "19": "4.75rem",

--- a/yarn.lock
+++ b/yarn.lock
@@ -187,7 +187,7 @@
   dependencies:
     "@babel/types" "^7.23.0"
 
-"@babel/helper-module-imports@^7.18.6", "@babel/helper-module-imports@^7.22.15":
+"@babel/helper-module-imports@^7.16.7", "@babel/helper-module-imports@^7.18.6", "@babel/helper-module-imports@^7.22.15":
   version "7.22.15"
   resolved "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz#16146307acdc40cc00c3b2c647713076464bdbf0"
   integrity sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==
@@ -1074,7 +1074,7 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@babel/runtime@^7.11.2":
+"@babel/runtime@^7.11.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
   version "7.23.9"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz#47791a15e4603bb5f905bc0753801cf21d6345f7"
   integrity sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==
@@ -1241,6 +1241,39 @@
   dependencies:
     tslib "^2.0.0"
 
+"@emotion/babel-plugin@^11.11.0":
+  version "11.11.0"
+  resolved "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz#c2d872b6a7767a9d176d007f5b31f7d504bb5d6c"
+  integrity sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==
+  dependencies:
+    "@babel/helper-module-imports" "^7.16.7"
+    "@babel/runtime" "^7.18.3"
+    "@emotion/hash" "^0.9.1"
+    "@emotion/memoize" "^0.8.1"
+    "@emotion/serialize" "^1.1.2"
+    babel-plugin-macros "^3.1.0"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^4.0.0"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+    stylis "4.2.0"
+
+"@emotion/cache@^11.11.0", "@emotion/cache@^11.4.0":
+  version "11.11.0"
+  resolved "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz#809b33ee6b1cb1a625fef7a45bc568ccd9b8f3ff"
+  integrity sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==
+  dependencies:
+    "@emotion/memoize" "^0.8.1"
+    "@emotion/sheet" "^1.2.2"
+    "@emotion/utils" "^1.2.1"
+    "@emotion/weak-memoize" "^0.3.1"
+    stylis "4.2.0"
+
+"@emotion/hash@^0.9.1":
+  version "0.9.1"
+  resolved "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz#4ffb0055f7ef676ebc3a5a91fb621393294e2f43"
+  integrity sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==
+
 "@emotion/is-prop-valid@^0.8.2":
   version "0.8.8"
   resolved "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
@@ -1265,10 +1298,55 @@
   resolved "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz#c1ddb040429c6d21d38cc945fe75c818cfb68e17"
   integrity sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==
 
-"@emotion/unitless@^0.8.0":
+"@emotion/react@^11.8.1":
+  version "11.11.3"
+  resolved "https://registry.npmjs.org/@emotion/react/-/react-11.11.3.tgz#96b855dc40a2a55f52a72f518a41db4f69c31a25"
+  integrity sha512-Cnn0kuq4DoONOMcnoVsTOR8E+AdnKFf//6kUWc4LCdnxj31pZWn7rIULd6Y7/Js1PiPHzn7SKCM9vB/jBni8eA==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@emotion/babel-plugin" "^11.11.0"
+    "@emotion/cache" "^11.11.0"
+    "@emotion/serialize" "^1.1.3"
+    "@emotion/use-insertion-effect-with-fallbacks" "^1.0.1"
+    "@emotion/utils" "^1.2.1"
+    "@emotion/weak-memoize" "^0.3.1"
+    hoist-non-react-statics "^3.3.1"
+
+"@emotion/serialize@^1.1.2", "@emotion/serialize@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.3.tgz#84b77bfcfe3b7bb47d326602f640ccfcacd5ffb0"
+  integrity sha512-iD4D6QVZFDhcbH0RAG1uVu1CwVLMWUkCvAqqlewO/rxf8+87yIBAlt4+AxMiiKPLs5hFc0owNk/sLLAOROw3cA==
+  dependencies:
+    "@emotion/hash" "^0.9.1"
+    "@emotion/memoize" "^0.8.1"
+    "@emotion/unitless" "^0.8.1"
+    "@emotion/utils" "^1.2.1"
+    csstype "^3.0.2"
+
+"@emotion/sheet@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.2.tgz#d58e788ee27267a14342303e1abb3d508b6d0fec"
+  integrity sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA==
+
+"@emotion/unitless@^0.8.0", "@emotion/unitless@^0.8.1":
   version "0.8.1"
   resolved "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz#182b5a4704ef8ad91bde93f7a860a88fd92c79a3"
   integrity sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==
+
+"@emotion/use-insertion-effect-with-fallbacks@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz#08de79f54eb3406f9daaf77c76e35313da963963"
+  integrity sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==
+
+"@emotion/utils@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz#bbab58465738d31ae4cb3dbb6fc00a5991f755e4"
+  integrity sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg==
+
+"@emotion/weak-memoize@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz#d0fce5d07b0620caa282b5131c297bb60f9d87e6"
+  integrity sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==
 
 "@esbuild/aix-ppc64@0.19.11":
   version "0.19.11"
@@ -1527,11 +1605,26 @@
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz#ef20350fec605a7f7035a01764731b2de0f3782b"
   integrity sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==
 
+"@floating-ui/core@^1.0.0":
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz#fa41b87812a16bf123122bf945946bae3fdf7fc1"
+  integrity sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==
+  dependencies:
+    "@floating-ui/utils" "^0.2.1"
+
 "@floating-ui/core@^1.5.3":
   version "1.5.3"
   resolved "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.3.tgz#b6aa0827708d70971c8679a16cf680a515b8a52a"
   integrity sha512-O0WKDOo0yhJuugCx6trZQj5jVJ9yR0ystG2JaNAemYUWce+pmM6WUEFIibnWyEJKdrDxhm75NoSRME35FNaM/Q==
   dependencies:
+    "@floating-ui/utils" "^0.2.0"
+
+"@floating-ui/dom@^1.0.1":
+  version "1.6.3"
+  resolved "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz#954e46c1dd3ad48e49db9ada7218b0985cee75ef"
+  integrity sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==
+  dependencies:
+    "@floating-ui/core" "^1.0.0"
     "@floating-ui/utils" "^0.2.0"
 
 "@floating-ui/dom@^1.5.4":
@@ -1549,7 +1642,7 @@
   dependencies:
     "@floating-ui/dom" "^1.5.4"
 
-"@floating-ui/utils@^0.2.0":
+"@floating-ui/utils@^0.2.0", "@floating-ui/utils@^0.2.1":
   version "0.2.1"
   resolved "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz#16308cea045f0fc777b6ff20a9f25474dd8293d2"
   integrity sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==
@@ -2319,6 +2412,11 @@
   resolved "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz#90267db13f64d6e9ccb5ae3eac92786a7c77a516"
   integrity sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==
 
+"@types/parse-json@^4.0.0":
+  version "4.0.2"
+  resolved "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz#5950e50960793055845e956c427fc2b0d70c5239"
+  integrity sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==
+
 "@types/prop-types@*":
   version "15.7.11"
   resolved "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz#2596fb352ee96a1379c657734d4b913a613ad563"
@@ -2356,6 +2454,13 @@
   version "0.28.8"
   resolved "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.8.tgz#e51710572bcccf214306833c2438575d310b3e98"
   integrity sha512-SN9c4kxXZonFhbX4hJrZy37yw9e7EIxcpHCxQv5JUS18wDE5ovkQKlqQEkufdJCCMfuI9BnjUJvhYeJ9x5Ra7g==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-transition-group@^4.4.0":
+  version "4.4.10"
+  resolved "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz#6ee71127bdab1f18f11ad8fb3322c6da27c327ac"
+  integrity sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==
   dependencies:
     "@types/react" "*"
 
@@ -2811,6 +2916,15 @@ axobject-query@^3.2.1:
   dependencies:
     dequal "^2.0.3"
 
+babel-plugin-macros@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz#9ef6dc74deb934b4db344dc973ee851d148c50c1"
+  integrity sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    cosmiconfig "^7.0.0"
+    resolve "^1.19.0"
+
 babel-plugin-polyfill-corejs2@^0.4.7:
   version "0.4.8"
   resolved "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.8.tgz#dbcc3c8ca758a290d47c3c6a490d59429b0d2269"
@@ -3166,6 +3280,11 @@ console-table-printer@^2.11.1:
   dependencies:
     simple-wcswidth "^1.0.1"
 
+convert-source-map@^1.5.0:
+  version "1.9.0"
+  resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
+  integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
+
 convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
@@ -3189,6 +3308,17 @@ core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
+
+cosmiconfig@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz#1443b9afa596b670082ea46cbd8f6a62b84635f6"
+  integrity sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==
+  dependencies:
+    "@types/parse-json" "^4.0.0"
+    import-fresh "^3.2.1"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+    yaml "^1.10.0"
 
 crc-32@^1.2.0:
   version "1.2.2"
@@ -3446,6 +3576,14 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-helpers@^5.0.1:
+  version "5.2.1"
+  resolved "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
+  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 dom-walk@^0.1.0:
   version "0.1.2"
@@ -4003,6 +4141,11 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+find-root@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
+  integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
+
 find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
@@ -4455,6 +4598,13 @@ history@^5.3.0:
   integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
   dependencies:
     "@babel/runtime" "^7.7.6"
+
+hoist-non-react-statics@^3.3.1:
+  version "3.3.2"
+  resolved "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
 
 hosted-git-info@^2.1.4:
   version "2.8.9"
@@ -5177,6 +5327,11 @@ mdn-data@2.0.30:
   version "2.0.30"
   resolved "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz#ce4df6f80af6cfbe218ecd5c552ba13c4dfa08cc"
   integrity sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==
+
+memoize-one@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz#b2591b871ed82948aee4727dc6abceeeac8c1045"
+  integrity sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==
 
 memoize-resolver@~1.0.0:
   version "1.0.0"
@@ -5987,7 +6142,7 @@ react-i18next@^13.0.1:
     "@babel/runtime" "^7.22.5"
     html-parse-stringify "^3.0.1"
 
-react-is@^16.13.1:
+react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -6046,12 +6201,37 @@ react-rx@^2.1.3:
     observable-callback "^1.0.2"
     use-sync-external-store "^1.2.0"
 
+react-select@^5.8.0:
+  version "5.8.0"
+  resolved "https://registry.npmjs.org/react-select/-/react-select-5.8.0.tgz#bd5c467a4df223f079dd720be9498076a3f085b5"
+  integrity sha512-TfjLDo58XrhP6VG5M/Mi56Us0Yt8X7xD6cDybC7yoRMUNm7BGO7qk8J0TLQOua/prb8vUOtsfnXZwfm30HGsAA==
+  dependencies:
+    "@babel/runtime" "^7.12.0"
+    "@emotion/cache" "^11.4.0"
+    "@emotion/react" "^11.8.1"
+    "@floating-ui/dom" "^1.0.1"
+    "@types/react-transition-group" "^4.4.0"
+    memoize-one "^6.0.0"
+    prop-types "^15.6.0"
+    react-transition-group "^4.3.0"
+    use-isomorphic-layout-effect "^1.1.2"
+
 react-style-proptype@^3.2.2:
   version "3.2.2"
   resolved "https://registry.npmjs.org/react-style-proptype/-/react-style-proptype-3.2.2.tgz#d8e998e62ce79ec35b087252b90f19f1c33968a0"
   integrity sha512-ywYLSjNkxKHiZOqNlso9PZByNEY+FTyh3C+7uuziK0xFXu9xzdyfHwg4S9iyiRRoPCR4k2LqaBBsWVmSBwCWYQ==
   dependencies:
     prop-types "^15.5.4"
+
+react-transition-group@^4.3.0:
+  version "4.4.5"
+  resolved "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
+  integrity sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react-use-measure@^2.1.1:
   version "2.1.1"
@@ -6257,7 +6437,7 @@ resolve-pkg-maps@^1.0.0:
   resolved "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz#616b3dc2c57056b5588c31cdf4b3d64db133720f"
   integrity sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==
 
-resolve@^1.1.7, resolve@^1.10.0, resolve@^1.14.2, resolve@^1.22.2, resolve@^1.22.4:
+resolve@^1.1.7, resolve@^1.10.0, resolve@^1.14.2, resolve@^1.19.0, resolve@^1.22.2, resolve@^1.22.4:
   version "1.22.8"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
   integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
@@ -6633,6 +6813,11 @@ source-map-js@^1.0.1, source-map-js@^1.0.2:
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
+source-map@^0.5.7:
+  version "0.5.7"
+  resolved "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+  integrity sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==
+
 space-separated-tokens@^1.0.0:
   version "1.1.5"
   resolved "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz#85f32c3d10d9682007e917414ddc5c26d1aa6899"
@@ -6855,6 +7040,11 @@ styled-jsx@5.1.1:
   integrity sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==
   dependencies:
     client-only "0.0.1"
+
+stylis@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz#79daee0208964c8fe695a42fcffcac633a211a51"
+  integrity sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==
 
 stylis@^4.3.0:
   version "4.3.1"
@@ -7312,6 +7502,11 @@ use-hot-module-reload@^1.0.1:
   resolved "https://registry.npmjs.org/use-hot-module-reload/-/use-hot-module-reload-1.0.3.tgz#fb2fbc062a99fbc173cec35086048ee7578318dc"
   integrity sha512-Wk/sjFhOF+a6PkovJvDAT3c8yE1DluZsSB3L+gTS8pM4ht2yg/LqBj4YLwnYJSdPnFqGWvu93CMdso8bcKw36A==
 
+use-isomorphic-layout-effect@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz#497cefb13d863d687b08477d9e5a164ad8c1a6fb"
+  integrity sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==
+
 use-sidecar@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz#2f43126ba2d7d7e117aa5855e5d8f0276dfe73c2"
@@ -7556,6 +7751,11 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yaml@^1.10.0:
+  version "1.10.2"
+  resolved "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yaml@^2.3.4:
   version "2.3.4"


### PR DESCRIPTION
# Changes

- Added a filter to the All Articles and All Projects page, so that it's possible to filter articles and projects based on which skills were used for them
- Added a filter to the skills for the project teasers and the individual project page skill badges so that a limited quantity are displayed

# Tested in

- Brave