### PR TITLE
add: ux hints to scroll down and go on the project individual pages

### DIFF
--- a/src/components/ProjectLink.tsx
+++ b/src/components/ProjectLink.tsx
@@ -65,10 +65,13 @@ const Project = ({
         <div
           className={clsx(
             colorPrimary,
-            "absolute right-8 top-8 flex h-8 w-8 origin-top-right rounded-full border-[2px] border-solid border-current p-1 transition-transform group-hover:scale-150 xl:right-6 xl:top-6 xl:h-10 xl:w-10 xl:border-2 xl:p-2",
+            "absolute right-8 top-8 flex origin-top-right items-center gap-1 rounded-full border-2 border-solid border-current p-2 transition-transform group-hover:scale-125 sm:gap-2 xl:right-6 xl:top-6",
           )}
         >
-          <ArrowForward />
+          <p className="text-label">See project</p>
+          <div className="w-4">
+            <ArrowForward />
+          </div>
         </div>
       </Link>
     </li>

--- a/src/components/menu/ButtonClose.tsx
+++ b/src/components/menu/ButtonClose.tsx
@@ -17,7 +17,7 @@ const ButtonClose = ({
       }}
       className={clsx(
         color,
-        "pointer-events-auto absolute right-4 top-4 h-10 w-10 cursor-pointer rounded-full border-2 border-solid border-current bg-[rgba(255,255,255,0)] p-2.5 transition-transform hover:scale-125 active:scale-150 sm:hidden",
+        "pointer-events-auto absolute right-4 top-4 z-20 h-10 w-10 cursor-pointer rounded-full border-2 border-solid border-current bg-[rgba(255,255,255,0)] p-2.5 transition-transform hover:scale-125 active:scale-150 sm:hidden",
       )}
     >
       {menuIsOpen ? (

--- a/src/components/menu/index.tsx
+++ b/src/components/menu/index.tsx
@@ -69,88 +69,90 @@ const Menu = ({
   }, [menuIsOpen, width]);
 
   return (
-    <header
-      className="pointer-events-none fixed z-10 grid h-full w-full grid-rows-[1fr_auto]"
-      ref={ref}
-    >
-      <ButtonClose
-        menuIsOpen={menuIsOpen}
-        setMenuIsOpen={setMenuIsOpen}
-        color={colorPrimary}
-      />
-      <div
-        className={clsx(
-          classNameMenuGap,
-          "z-10 flex w-full justify-center sm:absolute sm:top-6 sm:mx-4 sm:items-start xl:top-7",
-        )}
+    <>
+      <header
+        className="pointer-events-none fixed z-10 grid h-full w-full grid-rows-[1fr_auto]"
+        ref={ref}
       >
+        <ButtonClose
+          menuIsOpen={menuIsOpen}
+          setMenuIsOpen={setMenuIsOpen}
+          color={colorPrimary}
+        />
         <div
           className={clsx(
-            { hidden: !menuIsOpen },
-            colorPrimary,
             classNameMenuGap,
-            "flex w-full flex-col items-center justify-center p-16 sm:flex sm:w-fit sm:flex-row sm:bg-[rgba(255,255,255,0)] sm:p-0",
+            "z-10 flex w-full justify-center sm:absolute sm:top-6 sm:mx-4 sm:items-start xl:top-7",
           )}
         >
-          <nav>
-            <ul
-              className={clsx(
-                classNameMenuGap,
-                "flex flex-col items-center justify-center sm:flex-row",
-              )}
-            >
-              {menuLinksKeys
-                .filter((internalLinkKey) => internalLinkKey !== pageId)
-                .map((internalLinkKey) => (
-                  <InternalLink
-                    color={colorPrimary}
-                    key={`internal-link-${internalLinkKey}`}
-                    {...internalLinks[internalLinkKey]}
-                  />
-                ))}
-            </ul>
-          </nav>
-          <a
-            href="/resume_Ludivine_Constanti.pdf"
-            className={clsx(colorPrimary, "menu-link gap-1.5")}
-            download
+          <div
+            className={clsx(
+              { hidden: !menuIsOpen },
+              colorPrimary,
+              classNameMenuGap,
+              "flex w-full flex-col items-center justify-center p-16 sm:flex sm:w-fit sm:flex-row sm:bg-[rgba(255,255,255,0)] sm:p-0",
+            )}
           >
-            Resume
-            <span className="w-[0.55rem]">
-              <ArrowDownload />
-            </span>
-          </a>
-        </div>
-        {skillsFilter && menuIsOpen === false && (
-          <div className="relative top-5 sm:top-0">
-            <SearchBar skillsFilter={skillsFilter} />
+            <nav>
+              <ul
+                className={clsx(
+                  classNameMenuGap,
+                  "flex flex-col items-center justify-center sm:flex-row",
+                )}
+              >
+                {menuLinksKeys
+                  .filter((internalLinkKey) => internalLinkKey !== pageId)
+                  .map((internalLinkKey) => (
+                    <InternalLink
+                      color={colorPrimary}
+                      key={`internal-link-${internalLinkKey}`}
+                      {...internalLinks[internalLinkKey]}
+                    />
+                  ))}
+              </ul>
+            </nav>
+            <a
+              href="/resume_Ludivine_Constanti.pdf"
+              className={clsx(colorPrimary, "menu-link gap-1.5")}
+              download
+            >
+              Resume
+              <span className="w-[0.55rem]">
+                <ArrowDownload />
+              </span>
+            </a>
           </div>
-        )}
-      </div>
-      <ul
-        className={clsx(
-          { "hidden sm:flex": !menuIsOpen },
-          colorSecondary,
-          "flex h-full flex-wrap justify-center gap-6 px-12 py-16 sm:absolute sm:right-6 sm:top-0 sm:flex-col sm:bg-[rgba(255,255,255,0)] sm:p-0 xl:right-7",
-        )}
-      >
-        {socialMediasKeys.map((socialMediaKey) => (
-          <SocialMedia
-            key={`social-media-${socialMediaKey}`}
-            color={colorPrimary}
-            {...socialMedias[socialMediaKey]}
-          />
-        ))}
-      </ul>
+          {skillsFilter && menuIsOpen === false && (
+            <div className="relative top-5 sm:top-0">
+              <SearchBar skillsFilter={skillsFilter} />
+            </div>
+          )}
+        </div>
+        <ul
+          className={clsx(
+            { "hidden sm:flex": !menuIsOpen },
+            colorSecondary,
+            "flex h-full flex-wrap justify-center gap-6 px-12 py-16 sm:absolute sm:right-6 sm:top-0 sm:flex-col sm:bg-[rgba(255,255,255,0)] sm:p-0 xl:right-7",
+          )}
+        >
+          {socialMediasKeys.map((socialMediaKey) => (
+            <SocialMedia
+              key={`social-media-${socialMediaKey}`}
+              color={colorPrimary}
+              {...socialMedias[socialMediaKey]}
+            />
+          ))}
+        </ul>
+      </header>
       {bottomNavigationLinks && menuIsOpen === false && (
-        <nav className="absolute bottom-0 left-0 w-full">
+        <nav className="fixed bottom-0 left-0 z-10 w-full">
           <BottomNavigation
             colorPrimary={colorPrimary}
             bottomNavigationLinks={bottomNavigationLinks}
           />
         </nav>
       )}
-    </header>
+    </>
   );
 };
 

--- a/src/components/pageHome/Hero.tsx
+++ b/src/components/pageHome/Hero.tsx
@@ -1,6 +1,6 @@
 const Hero = () => {
   return (
-    <div className="mx-sm mx-xl grid h-screen sm:grid-cols-2 sm:items-center">
+    <div className="mx-sm mx-xl relative grid h-[100dvh] sm:grid-cols-2 sm:items-center">
       <div className="col-end-[-1] flex justify-center">
         <section className="mt-40 h-fit bg-[rgba(23,37,84,0.75)] p-2 px-8 sm:mt-0 sm:px-2">
           <h1 className="text-h4 pointer-events-auto font-light">
@@ -10,12 +10,27 @@ const Hero = () => {
             Full Stack Developer 🚀
           </h2>
           <p className="text-body pointer-events-auto max-w-[25rem]">
-            Technology enthusiast, life-long learner ✨
-            <br />
-            Creating digital experiences for award-winning agencies since 2017
-            🏆
+            Welcome to my portfolio!
+            <br />I am a technology enthusiast, life-long learner ✨ Creating
+            digital experiences for award-winning agencies since 2017 🏆
           </p>
         </section>
+      </div>
+      <div className="text-body absolute bottom-12 left-[50%] flex translate-x-[-50%] animate-bounce flex-col items-center gap-1  rounded-xl bg-blue-950 p-2 sm:bottom-12">
+        <p>Scroll Down</p>
+        <div className="w-4">
+          <svg
+            width="100%"
+            viewBox="0 0 14 9"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M2.09399 0.894592C1.70361 0.504211 1.07031 0.504211 0.679932 0.894592C0.289307 1.28522 0.289307 1.91827 0.679932 2.3089L6.33667 7.96564C6.43433 8.06329 6.54712 8.13654 6.66748 8.18536C6.92041 8.2879 7.20703 8.28278 7.45654 8.16974C7.56445 8.1214 7.66626 8.0545 7.75488 7.96588L13.4119 2.3089C13.8022 1.91852 13.8022 1.28522 13.4119 0.894836C13.0212 0.504211 12.3882 0.504211 11.9976 0.894836L7.0459 5.8465L2.09399 0.894592Z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
       </div>
     </div>
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -19,6 +19,18 @@ const config: Config = {
         "19": "4.75rem",
         "22": "5.5rem",
       },
+      keyframes: {
+        bounce: {
+          "0%, 100%": {
+            transform: "translateY(-25%) translateX(-50%)",
+            animationTimingFunction: "cubic-bezier(0.8, 0, 1, 1)",
+          },
+          "50%": {
+            transform: "translateY(0) translateX(-50%)",
+            animationTimingFunction: "cubic-bezier(0, 0, 0.2, 1)",
+          },
+        },
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
# Changes

- Added a hint to scroll down on the home page
- Added a hint to click on the project links

# Bug fixing

- The navigation at the bottom now goes up and down depending on whether the mobile menu (from the browser) is visible
- The close button of the mobile menu now displays again when the menu is open

# Tested in

- Brave