### PR TITLE
fix: skills are now displayed in alphabetical order in the search of …

### DIFF
--- a/src/pages/all-articles.tsx
+++ b/src/pages/all-articles.tsx
@@ -33,7 +33,7 @@ export const getStaticProps = async () => {
         date,
         ${querySkillBadges}
       },
-      "skills": *[_type == "skillBadge"]{
+      "skills": *[_type == "skillBadge"] | order(text asc){
         _id,
         text,
       }


### PR DESCRIPTION
# Changes

- skills are now displayed in alphabetical order in the search of the all articles page